### PR TITLE
fix slick driver initialization under scala 2.12

### DIFF
--- a/dialog-storage-slick/src/main/scala/im/dlg/storage/slick/SlickConnector.scala
+++ b/dialog-storage-slick/src/main/scala/im/dlg/storage/slick/SlickConnector.scala
@@ -8,7 +8,9 @@ import im.dlg.storage.api.Action
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-private object Driver extends ExPostgresProfile with PgArraySupport {
+private object Driver extends Driver
+
+private trait Driver extends ExPostgresProfile with PgArraySupport {
   override val api = PgAPI
 
   object PgAPI extends API with ByteaPlainImplicits

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1"
+version in ThisBuild := "0.1.2"


### PR DESCRIPTION
fixes slick driver initialization under scala 2.12
`java.lang.AbstractMethodError: Method im/dlg/storage/slick/Driver$PgAPI$.slick$basic$BasicProfile$API$_setter_$Database_$eq(Ljava/lang/Object;)V is abstract`